### PR TITLE
Update file extension to match instructions

### DIFF
--- a/Docs/Kubernetes/Storage.md
+++ b/Docs/Kubernetes/Storage.md
@@ -89,5 +89,5 @@
 <p><img src="https://help.turingpi.com/hc/article_attachments/9072471290781" alt="longhorn_ui_4.png"></p>
 <h3><span class="wysiwyg-color-black">Cleanup</span></h3>
 <p>Delete the PVC with:</p>
-<pre>kubectl delete -f pvc_test.yam</pre>
+<pre>kubectl delete -f pvc_test.yaml</pre>
 <p><span class="wysiwyg-color-green120"><strong>W</strong><strong>e can now assume the test was successful and this StorageClass can be used across our cluster.</strong></span></p>


### PR DESCRIPTION
This pull request addresses a file extension mismatch in the cleanup command of the instructions. The instructions ask to create `pvc_test.yaml` using `kubectl apply -f pvc_test.yaml`. However, the cleanup command incorrectly suggests using `kubectl delete -f pvc_test.yam` instead of `pvc_test.yaml`.

To correct this, this pull request updates the cleanup command in the instructions to use the correct file extension: `kubectl delete -f pvc_test.yaml`